### PR TITLE
minor updates:

### DIFF
--- a/src/ODBCStatement.cpp
+++ b/src/ODBCStatement.cpp
@@ -274,7 +274,7 @@ QoreHashNode* ODBCStatement::describe(ExceptionSink* xsink) {
     return h.release();
 }
 
-void ODBCStatement::doColumns(QoreHashNode& h, std::vector<QoreListNode*>& columns) {
+void ODBCStatement::populateColumnHash(QoreHashNode& h, std::vector<QoreListNode*>& columns) {
     int columnCount = resColumns.size();
     columns.resize(columnCount);
 

--- a/src/ODBCStatement.cpp
+++ b/src/ODBCStatement.cpp
@@ -315,7 +315,7 @@ QoreHashNode* ODBCStatement::getOutputHash(ExceptionSink* xsink, bool emptyHashI
                 return 0;
 
             if (h->empty())
-               doColumns(**h, columns);
+               populateColumnHash(**h, columns);
 
             (columns[j])->push(n.release());
         }
@@ -326,7 +326,7 @@ QoreHashNode* ODBCStatement::getOutputHash(ExceptionSink* xsink, bool emptyHashI
     }
 
     if (!rowCount && !emptyHashIfNothing)
-       doColumns(**h, columns);
+       populateColumnHash(**h, columns);
 
     return h.release();
 }

--- a/src/ODBCStatement.h
+++ b/src/ODBCStatement.h
@@ -237,8 +237,11 @@ private:
     //! Result columns metadata.
     std::vector<ODBCResultColumn> resColumns;
 
-    // populate column hash
-    DLLLOCAL void doColumns(QoreHashNode& h, std::vector<QoreListNode*>& columns);
+    //! Populate column hash.
+    /** @param h column hash
+        @param columns reference to a shortcut vector for column lists
+     */
+    DLLLOCAL void populateColumnHash(QoreHashNode& h, std::vector<QoreListNode*>& columns);
 
     //! Fetch metadata about result columns.
     /** @param xsink exception sink
@@ -458,20 +461,20 @@ private:
 
 class HashColumnAssignmentHelper : public HashAssignmentHelper {
 public:
-   DLLLOCAL HashColumnAssignmentHelper(QoreHashNode& h, const std::string& name) : HashAssignmentHelper(h, name.c_str()) {
+    DLLLOCAL HashColumnAssignmentHelper(QoreHashNode& h, const std::string& name) : HashAssignmentHelper(h, name.c_str()) {
         if (!**this)
-           return;
+            return;
 
         // Find a unique column name.
         unsigned num = 1;
         while (true) {
-           QoreStringMaker tmp("%s_%d", name.c_str(), num);
-           reassign(tmp.c_str());
-           if (**this) {
-              ++num;
-              continue;
-           }
-           break;
+            QoreStringMaker tmp("%s_%d", name.c_str(), num);
+            reassign(tmp.c_str());
+            if (**this) {
+                ++num;
+                continue;
+            }
+            break;
         }
     }
 };

--- a/src/ODBCStatement.h
+++ b/src/ODBCStatement.h
@@ -37,23 +37,7 @@
 #include <sql.h>
 #include <sqlext.h>
 
-#include "qore/common.h"
-#include "qore/QoreEncoding.h"
-#include "qore/QoreString.h"
-#include "qore/QoreStringNode.h"
-#include "qore/AbstractQoreNode.h"
-#include "qore/AbstractPrivateData.h"
-#include "qore/BinaryNode.h"
-#include "qore/QoreHashNode.h"
-#include "qore/Datasource.h"
-#include "qore/ExceptionSink.h"
-#include "qore/DateTimeNode.h"
-#include "qore/QoreBoolNode.h"
-#include "qore/QoreBigIntNode.h"
-#include "qore/QoreFloatNode.h"
-#include "qore/QoreNumberNode.h"
-#include "qore/QoreListNode.h"
-#include "qore/QoreNullNode.h"
+#include <qore/Qore.h>
 
 #include "EnumNumericOption.h"
 #include "ErrorHelper.h"
@@ -252,6 +236,9 @@ private:
 
     //! Result columns metadata.
     std::vector<ODBCResultColumn> resColumns;
+
+    // populate column hash
+    DLLLOCAL void doColumns(QoreHashNode& h, std::vector<QoreListNode*>& columns);
 
     //! Fetch metadata about result columns.
     /** @param xsink exception sink
@@ -467,6 +454,26 @@ private:
         @return ODBC interval structure
      */
     DLLLOCAL inline SQL_INTERVAL_STRUCT getIntervalFromDate(const DateTimeNode* arg);
+};
+
+class HashColumnAssignmentHelper : public HashAssignmentHelper {
+public:
+   DLLLOCAL HashColumnAssignmentHelper(QoreHashNode& h, const std::string& name) : HashAssignmentHelper(h, name.c_str()) {
+        if (!**this)
+           return;
+
+        // Find a unique column name.
+        unsigned num = 1;
+        while (true) {
+           QoreStringMaker tmp("%s_%d", name.c_str(), num);
+           reassign(tmp.c_str());
+           if (**this) {
+              ++num;
+              continue;
+           }
+           break;
+        }
+    }
 };
 
 inline AbstractQoreNode* ODBCStatement::getColumnValue(int column, ODBCResultColumn& rcol, ExceptionSink* xsink) {
@@ -939,4 +946,3 @@ SQL_INTERVAL_STRUCT ODBCStatement::getIntervalFromDate(const DateTimeNode* arg) 
 }
 
 #endif // _QORE_MODULE_ODBC_ODBCSTATEMENT_H
-

--- a/test/odbc.qtest
+++ b/test/odbc.qtest
@@ -110,7 +110,8 @@ class OdbcTest inherits QUnit::Test {
         try {
             initDatasource();
         }
-        catch (e) {
+        catch (hash ex) {
+            printf("%s: %s\n", ex.err, ex.desc);
             exit(1);
         }
 
@@ -147,6 +148,7 @@ class OdbcTest inherits QUnit::Test {
             exit(1);
         }
         ds.open();
+        printf("ver: %y\n", ds.getServerVersion());
     }
 
     basicTest() {
@@ -245,4 +247,3 @@ class OdbcTest inherits QUnit::Test {
         assertEq(h, ds.select("SELECT * FROM " + tableName));
     }
 }
-


### PR DESCRIPTION
- only include `<qore/Qore.h>`
- do not use private functions (ex: `QoreHashNode::clear()` is not exported in the ABI - these DLLLOCAL functions need to be removed from the public Qore headers)
- other minor updates
